### PR TITLE
Java 23 Support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Pull Request Version Validation
-        uses: ikmdev/maven-pull-request-version-validation-action@v1.0.0
+        uses: ikmdev/maven-pull-request-version-validation-action@v2
         
   general-build-job:
     name: General Build

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,1 @@
-
+--enable-preview

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.1/apache-maven-3.9.1-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Team Ownership - Product Owner
 
 Required for running this:
 
-1. Download and install Open JDK Java 19
+1. Download and install Open JDK Java 23
 
 ## Building and Running
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>dev.ikm.build</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.57.0</version>
+		<version>1.58.0</version>
 		<relativePath></relativePath>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<groupId>dev.ikm.jpms</groupId>
 	<artifactId>httpclient5</artifactId>
 	<packaging>jar</packaging>
-	<version>5.4.2-r2-SNAPSHOT</version>
+	<version>5.4.2-r2-AR-299_Java23-SNAPSHOT</version>
 	<description>
 		Builds the httpclient5. 
 	</description>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<groupId>dev.ikm.jpms</groupId>
 	<artifactId>httpclient5</artifactId>
 	<packaging>jar</packaging>
-	<version>5.4.2-r2-AR-299_Java23-SNAPSHOT</version>
+	<version>5.4.2-r2-SNAPSHOT</version>
 	<description>
 		Builds the httpclient5. 
 	</description>


### PR DESCRIPTION
Java 23 changes:

* Update Maven (wrapper) to 3.9.9
* Update build parent for Java 23
* Update GitHub actions for Java 23

